### PR TITLE
HIVE-21721  nvl function fail with NullPointerException

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TypeCheckProcFactory.java
@@ -1691,7 +1691,7 @@ public class TypeCheckProcFactory {
         return getXpathOrFuncExprNodeDesc(expr, isFunction, children, ctx);
       } catch (UDFArgumentTypeException e) {
         throw new SemanticException(ErrorMsg.INVALID_ARGUMENT_TYPE.getMsg(expr
-            .getChild(childrenBegin + e.getArgumentId()), e.getMessage()), e);
+            , e.getMessage()), e);
       } catch (UDFArgumentLengthException e) {
         throw new SemanticException(ErrorMsg.INVALID_ARGUMENT_LENGTH.getMsg(
             expr, e.getMessage()), e);


### PR DESCRIPTION
nvl function when facing the INVALID_ARGUMENT_TYPE exception,the reasons may show friendly to the users,any advice on the PR will be appreciated